### PR TITLE
feat: ensure generator can run without fields flag

### DIFF
--- a/bin/actions.js
+++ b/bin/actions.js
@@ -22,6 +22,8 @@ const gen = async ({ schema: schemaFilePath, entity, fields }) => {
   };
   const mock = await getMocks({ query, schema: newSchema, variables });
   console.log(JSON.stringify(mock, null, "  "));
+
+  return mock;
 };
 
 const run = ({ schema: schemaFilePath, config: configFilePath, port }) => {

--- a/bin/utils.js
+++ b/bin/utils.js
@@ -7,7 +7,7 @@ const getTypeDefinition = (schema, type) => {
 };
 const recursivelyGetFields = (schema, fields) => {
   return fields.map(({ name, type }) => {
-    const { value } = type.type.name;
+    const { value } = type?.type?.name ?? type.name;
     const fieldName = name.value;
 
     if (isNativeGraphqlType(value)) {
@@ -37,7 +37,13 @@ const getEntityFields = (schema, entity) => {
   return recursivelyGetFields(parsedSchema, entityTypeDefinition.fields);
 };
 
-const formatFields = (fields) => fields.split(",").join(" ");
+const formatFields = (fields) => {
+  let splitFields = fields.split(",").join(" ");
+  splitFields = splitFields.replaceAll("[", "{");
+  splitFields = splitFields.replaceAll("]", "}");
+
+  return splitFields;
+};
 
 module.exports = {
   getEntityFields,

--- a/src/tests/bin/actions-schema.graphql
+++ b/src/tests/bin/actions-schema.graphql
@@ -1,0 +1,20 @@
+type Account {
+  id: Int!
+  name: String!
+  email: String!
+  password: String!
+  token: Token!
+}
+
+type Token {
+  header: String!
+  payload: Payload!
+  signature: Int!
+}
+
+type Payload {
+  userName: String!
+  userId: ID!
+  userEmail: String!
+  isActiveUser: Boolean!
+}

--- a/src/tests/bin/actions.test.ts
+++ b/src/tests/bin/actions.test.ts
@@ -1,0 +1,47 @@
+import { gen } from "../../../bin/actions";
+
+describe("Gen", () => {
+  const schema = "./src/tests/bin/actions-schema.graphql";
+  const entity = "Account";
+  test("Should return all fields for entity if none are specified", async () => {
+    const mock = await gen({ schema, entity, fields: "" });
+    expect(mock).toEqual({
+      id: expect.any(Number),
+      name: expect.any(String),
+      email: expect.any(String),
+      password: expect.any(String),
+      token: {
+        header: expect.any(String),
+        signature: expect.any(Number),
+        payload: {
+          userName: expect.any(String),
+          userId: expect.any(String),
+          userEmail: expect.any(String),
+          isActiveUser: expect.any(Boolean),
+        },
+      },
+    });
+  });
+
+  test("Should return only specified fields for entity", async () => {
+    const fields = "id,name,token[header,payload[userId]]";
+
+    const mock = await gen({ schema, entity, fields });
+
+    expect(mock).toEqual({
+      id: expect.any(Number),
+      name: expect.any(String),
+      token: {
+        header: expect.any(String),
+        payload: {
+          userId: expect.any(String),
+        },
+      },
+    });
+
+    expect(mock).not.toHaveProperty("email");
+    expect(mock).not.toHaveProperty("password");
+    expect(mock.token).not.toHaveProperty("signature");
+    expect(mock.token.payload).not.toHaveProperty("isActiveUser");
+  });
+});


### PR DESCRIPTION
PR created to fix issue: https://github.com/bitovi/stateful-mocks/issues/38

This PR intends to allow the generator to be used in two ways:

* To generate all fields:  ./bin/cli.js gen -s mocks/schema.graphql -e Account
* To generate specified fields, separated by comma:  ./bin/cli.js gen -s mocks/schema.graphql -e Account -f name,token[header,payload[userId]] 